### PR TITLE
fix: Add marketplace.json and correct plugin installation instructions

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -31,11 +31,20 @@ Sugar is a premier Claude Code plugin that brings true autonomous development to
 
 ### Installation
 
-Install the Sugar plugin via Claude Code:
+Install the Sugar plugin via Claude Code using one of these methods:
 
+**Option 1: Direct Repository Installation (Recommended)**
 ```
+/plugin install cdnsteve/sugar
+```
+
+**Option 2: Register Sugar Marketplace First**
+```
+/plugin marketplace add cdnsteve/sugar
 /plugin install sugar
 ```
+
+**Note**: The plugin is available from the `cdnsteve/sugar` GitHub repository. If you get "Plugin not found in any marketplace", use the direct installation method above.
 
 ### Basic Usage
 
@@ -163,6 +172,6 @@ MIT License - see [LICENSE](https://github.com/cdnsteve/sugar/blob/main/LICENSE)
 
 ---
 
-**Sugar 🍰 v1.9.1** - Transform any project into an autonomous development environment.
+**Sugar 🍰 v2.1.0** - Transform any project into an autonomous development environment.
 
 ⚠️ **Disclaimer**: Sugar is an independent third-party tool. "Claude," "Claude Code," and related marks are trademarks of Anthropic, Inc. Sugar is not affiliated with, endorsed by, or sponsored by Anthropic, Inc.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "sugar-plugins",
+  "version": "1.0.0",
+  "description": "Sugar - AI-powered autonomous development system for complex, multi-step development tasks",
+  "owner": {
+    "name": "Steven Leggett",
+    "email": "contact@roboticforce.io"
+  },
+  "plugins": [
+    {
+      "name": "sugar",
+      "description": "Transform Claude Code into an autonomous AI development powerhouse with persistent task management, intelligent agents, and automatic work discovery",
+      "version": "2.1.0",
+      "author": {
+        "name": "Steven Leggett",
+        "email": "contact@roboticforce.io"
+      },
+      "source": ".",
+      "category": "development"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -211,8 +211,10 @@ discovery:
 ### Install the Plugin
 
 ```
-/plugin install sugar@cdnsteve
+/plugin install cdnsteve/sugar
 ```
+
+> **Note**: If you see "Plugin not found in any marketplace", make sure you're using `cdnsteve/sugar` (the GitHub repository path).
 
 ### Delegate Work from Claude
 


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` with proper Claude Code schema format
- Updates installation instructions to use the correct `cdnsteve/sugar` repository path format
- Adds helpful note for users encountering "Plugin not found" error

## Root Cause
Users were trying to install with:
- `/plugin install sugar` - Not in any official marketplace
- `/plugin install sugar@cdnsteve` - Incorrect syntax

The correct syntax for direct repository installation is:
```
/plugin install cdnsteve/sugar
```

## Changes
1. **New file**: `.claude-plugin/marketplace.json` - Proper marketplace manifest following Claude Code's schema
2. **Updated**: `.claude-plugin/README.md` - Clear installation options
3. **Updated**: `README.md` - Correct install command with helpful note

## Test plan
- [x] marketplace.json is valid JSON with correct schema
- [x] All plugin structure tests pass (25 passed)
- [x] Documentation is clear and accurate

## Installation Options (after this PR)

**Option 1: Direct Repository Installation (Recommended)**
```
/plugin install cdnsteve/sugar
```

**Option 2: Register Marketplace First**
```
/plugin marketplace add cdnsteve/sugar
/plugin install sugar
```

Fixes #8