### PR TITLE
feat: Improve Ralph Wiggum UX with --completion-promise flag

### DIFF
--- a/docs/ralph-wiggum.md
+++ b/docs/ralph-wiggum.md
@@ -2,6 +2,26 @@
 
 Sugar integrates the Ralph Wiggum iterative development technique for complex tasks that benefit from self-correction and refinement.
 
+## Quick Start
+
+The simplest way to use Ralph:
+
+```bash
+# 1. Add a task with --ralph flag
+sugar add "Fix the auth bug" --type bug_fix --ralph \
+  --completion-promise "BUG FIXED"
+
+# 2. Run Sugar (Ralph iterates automatically in the background)
+sugar run
+```
+
+**Key Points:**
+- `--ralph` enables iterative execution for the task
+- `--completion-promise` sets the signal that marks completion (optional, defaults to "DONE")
+- `--max-iterations` limits attempts (optional, defaults to 10)
+- Each iteration, Claude sees previous work and continues improving
+- Task completes when the promise signal is output or max iterations reached
+
 ## What is Ralph Wiggum?
 
 The Ralph Wiggum technique, pioneered by [Geoffrey Huntley](https://ghuntley.com/ralph/), is an iterative AI loop methodology:
@@ -62,10 +82,19 @@ sugar:
 
 ```bash
 # Add a task that will use Ralph iterations
-sugar add "Fix flaky auth tests" --type complex_bug --ralph
+sugar add "Fix flaky auth tests" --type bug_fix --ralph
+
+# Add with custom completion signal
+sugar add "Implement caching" --ralph --completion-promise "CACHING COMPLETE"
 
 # Add with custom iteration limit
 sugar add "Refactor cache module" --ralph --max-iterations 15
+
+# Full example with all options
+sugar add "Refactor auth to JWT" --type refactor --ralph \
+  --completion-promise "JWT AUTH COMPLETE" \
+  --max-iterations 20 \
+  --description "Migrate from session-based to JWT. All auth tests must pass."
 ```
 
 ### Via Task Queue

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -95,6 +95,32 @@ sugar add TITLE [OPTIONS]
 - `--stdin` - Read task data from stdin (JSON format)
 - `--json` - Parse description as JSON and store in context
 
+**Ralph Wiggum Options (Iterative Execution):**
+- `--ralph` - Enable iterative execution for complex tasks that benefit from self-correction
+- `--completion-promise TEXT` - Custom completion signal (default: DONE). Requires `--ralph`
+- `--max-iterations INTEGER` - Maximum iterations before auto-stopping (default: 10)
+
+Ralph mode runs tasks iteratively until completion criteria are met. Each iteration, Claude sees previous work and continues improving. Ideal for:
+- Complex debugging requiring multiple attempts
+- TDD workflows (write tests, implement, refine)
+- Exploratory refactoring
+- Tasks with clear success criteria (tests pass, linting clean)
+
+**Ralph Examples:**
+```bash
+# Simple iterative bug fix
+sugar add "Fix auth timeout" --type bug_fix --ralph
+
+# With custom completion signal
+sugar add "Implement rate limiting" --type feature --ralph \
+  --completion-promise "RATE LIMITING COMPLETE"
+
+# With higher iteration limit for complex refactoring
+sugar add "Refactor database layer" --type refactor --ralph \
+  --max-iterations 20 \
+  --description "Refactor to repository pattern. Output <promise>REFACTOR DONE</promise> when tests pass."
+```
+
 **Standard Examples:**
 ```bash
 # Basic task


### PR DESCRIPTION
## Summary

- Add `--completion-promise` CLI flag for custom completion signals
- Change validation to strict mode (reject tasks with weak completion criteria)
- Add Ralph section to CLI reference documentation
- Add Quick Start section to Ralph documentation

## Changes

### Code (`sugar/main.py`)
- New `--completion-promise TEXT` option (requires `--ralph`)
- Validation changed from `strict=False` to `strict=True`
- Invalid tasks now rejected with error instead of warning

### Documentation
- `docs/user/cli-reference.md`: Added "Ralph Wiggum Options" section with examples
- `docs/ralph-wiggum.md`: Added Quick Start section at top

## Usage

```bash
# Before (awkward):
sugar add "Fix bug" --ralph --description "Fix it. Output: <promise>DONE</promise>"

# After (clean):
sugar add "Fix bug" --ralph --completion-promise "BUG FIXED"
```

## Test plan

- [x] All 51 Ralph tests pass
- [x] New flags appear in `sugar add --help`
- [ ] Manual testing of --completion-promise flag

Closes #28